### PR TITLE
Feature/19 voltage based linear profile

### DIFF
--- a/src/Milton/Command/linear.pm
+++ b/src/Milton/Command/linear.pm
@@ -11,6 +11,7 @@ use Milton::Math::PiecewiseLinear;
 use Data::Dumper;
 use Math::Round qw(round);
 use Milton::Config::Path qw(resolve_writable_config_path unresolve_file_path);
+use Carp qw(croak);
 
 use Milton::DataLogger qw(get_namespace_debug_level);
 
@@ -125,11 +126,8 @@ sub preprocess {
   $self->buildProfile($status);
 
   # Ensure that we have some current through the hotplate so we will be able to measure resistance and set output power.
-  $self->{interface}->setCurrent($self->{config}->{current}->{startup});
-  sleep(0.5);
-  $self->{interface}->poll;
+  $self->startupCurrent($status);
 
-  $self->{controller}->getTemperature($status);
   $self->{'current-stage'} = $self->nextStage($self->{'profile'}->{stages}->[0], $status);
 
   return $status;
@@ -168,6 +166,36 @@ sub trimPowerOutput {
   return $trim_factor;
 }
 
+sub _calculate_voltage_for_power {
+  my ($self, $power, $rmin, $rmax) = @_;
+  my $log_mean = ($rmax - $rmin) / log($rmax / $rmin);
+  
+  if ($log_mean < $rmin || $log_mean > $rmax) {
+    croak "Log Mean Out of Bounds: %03f <= %03f <= %03f", $rmin, $log_mean, $rmax;
+  }
+
+  return sqrt($power * $log_mean);
+}
+
+sub _get_resistance {
+  my ($self, $status) = @_;
+
+  if (exists $status->{resistance}) {
+    return $status->{resistance};
+  }
+
+  if (exists($status->{current}) && exists($status->{voltage}) && $status->{current} > 0 && $status->{voltage} > 0) {
+    return $status->{voltage} / $status->{current};
+  }
+
+  my $temperature = $status->{temperature} // $status->{'device-temperature'} // $status->{ambient};
+  if (defined $temperature) {
+    return $self->{controller}->estimateResistance($temperature);
+  }
+
+  croak "Unable to determine hotplate resistance";
+}
+
 sub nextStage {
   my ($self, $stage, $status) = @_;
 
@@ -200,19 +228,31 @@ sub nextStage {
     $ideal->setNamedPoint($prev->{'.end'}, $prev->{temperature}, $prev->{name});
   }
 
+  # Trim the output to adjust for load, but only if we're not tuning!
+  $self->trimPowerOutput($prev) if !$self->{tune};
+
   # Detect stage direction and normalize temperature limits to make calculations easier
   if ($stage->{'.direction'} > 0) {
     $self->{'hi-temp'} = $stage->{temperature};
     $self->{'lo-temp'} = ($temperature // $status->{ambient}) - 20;
     $self->{timeout} += $stage->{duration};
-  } elsif ($stage->{'.direction'} <0) {
+
+    $stage->{'.trimmed-power'} = $stage->{power} * $self->{'ramp-trim'};
+  } elsif ($stage->{'.direction'} < 0) {
     $self->{'lo-temp'} = $stage->{temperature};
     $self->{'hi-temp'} = min(220, $temperature + 50);
     $self->{timeout} += $stage->{duration};
+  } else {
+    $stage->{'.trimmed-power'} = $stage->{power} * $self->{'flat-trim'};
   }
 
-  # Trim the output to adjust for load, but only if we're not tuning!
-  $self->trimPowerOutput($prev) if !$self->{tune};
+  # Calculate the mean resistance for the stage
+  my $r_now = $self->_get_resistance($status);
+  my $r_end = $self->{controller}->estimateResistance($stage->{temperature});
+  my $voltage = $self->_calculate_voltage_for_power($stage->{'.trimmed-power'}, min($r_now, $r_end), max($r_now, $r_end));
+  $stage->{'.start-resistance'} = $r_now;
+  $stage->{'.end-resistance'} = $r_end;
+  $stage->{'.voltage'} = $voltage;
 
   # Initialize the samples array for this stage
   $stage->{'.samples'} = [];
@@ -297,16 +337,17 @@ sub timerEvent {
 
   $status->{stage} = $stage->{name};
 
-  my $trimmedPower = $stage->{power};
-  if ($stage->{'.direction'} == 0) {
-    $trimmedPower = $trimmedPower * $self->{'flat-trim'};
-  } elsif ($stage->{'.direction'} > 0) {
-    $trimmedPower = $trimmedPower * $self->{'ramp-trim'};
+  $status->{'set-power'} = $stage->{'.trimmed-power'} // $stage->{power};
+  if (defined $stage->{'.voltage'}) {
+    $self->{interface}->setVoltage($stage->{'.voltage'});
+  } else {
+    $self->{interface}->setPower($status->{'set-power'});
   }
 
-  $self->{interface}->setPower($trimmedPower);
-  $status->{'set-power'} = $trimmedPower;
-  $self->debug('Stage power: %.1f, trimmed power: %.1f', $stage->{power}, $trimmedPower) if DEBUG_LEVEL >= DEBUG_CALCULATIONS;
+  $self->debug('Stage power: %.1f, Stage Voltage: %.1f, trimmed power: %.1f'
+             , $stage->{power}
+             , $stage->{'.voltage'}
+             , $stage->{'.trimmed-power'}) if DEBUG_LEVEL >= DEBUG_CALCULATIONS;
 
   return $status;
 }

--- a/src/Milton/Command/power.pm
+++ b/src/Milton/Command/power.pm
@@ -188,11 +188,6 @@ sub processTimerEvent {
 
   $self->{controller}->getTemperature($status);
 
-  # We don't need it for control, but getting the predicted temperature is useful for web UI display and data logging.
-  my $predictor = $self->{controller}->getPredictor;
-  if ($predictor) {
-    $predictor->predictTemperature($status);
-  }
   $status->{'set-power'} = $self->{power};
 
   # If we've passed the set duration, then power off and exit.

--- a/src/Milton/Command/voltage.pm
+++ b/src/Milton/Command/voltage.pm
@@ -1,0 +1,85 @@
+package Milton::Command::voltage;
+
+use strict;
+use warnings qw(all -uninitialized);
+
+use Time::HiRes qw(sleep);
+
+use base qw(Milton::Command::ManualTuningCommand);
+use Carp;
+use Milton::Config::Path qw(resolve_writable_config_path);
+
+use Milton::DataLogger qw(get_namespace_debug_level);
+
+use constant DEBUG_LEVEL => get_namespace_debug_level();
+use constant DEBUG_DATA => 100;
+
+=head1 NAME
+
+Milton::Command::voltage - Operate the hotplate at a constant voltage level until shut down by the user.
+
+=head1 SYNOPSIS
+
+    use Milton::Command::voltage;
+
+    my $voltage = Milton::Command::voltage->new();
+
+=head1 DESCRIPTION
+
+Operate the hotplate at a constant voltage level until shut down by the user. The command accepts
+a single argument - the voltage level in volts. It will then maintain the requested voltage level
+until the process is shut down by the user via Ctrl+C, a terminate signal or any other means
+by which the process is terminated. Upon shutdown, the command will ensure that the hotplate is
+turned off.
+
+=cut
+
+sub new {
+  my ($class, $config, $interface, $controller, @args) = @_;
+
+  my $self = $class->SUPER::new($config, $interface, $controller, @args);
+
+  $self->{voltage} = $self->{args}->[0] || $config->{voltage}->{default};
+
+  croak "Voltage level not specified." unless $self->{voltage};
+  croak "Voltage level must be a positive number: $self->{voltage}" unless $self->{voltage} > 0;
+  croak "Voltage level is crazy high: $self->{voltage}" unless $self->{voltage} <= $interface->{voltage}->{maximum};
+
+  return $self;
+}
+
+sub options {
+  return ( 'voltage=i'
+         , 'duration=i'
+         );
+}
+
+sub preprocess {
+  my ($self, $status) = @_;
+
+  $self->info("Voltage: $self->{voltage}");
+  $self->info("Duration: $self->{duration}") if $self->{duration};
+
+  $self->{interface}->setVoltage($self->{voltage});
+  sleep(0.5);
+  $self->{interface}->poll($status);
+
+  return $status;
+}
+
+sub timerEvent {
+  my ($self, $status) = @_;
+
+  # If we've passed the set duration, then power off and exit.
+  if ($self->{duration} && $status->{now} > $self->{duration}) {
+    $self->{interface}->on(0);
+    $self->beep;
+    return;
+  }
+
+  $self->{interface}->setVoltage($self->{voltage});
+
+  return $status;
+}
+
+1;

--- a/src/Milton/Controller/RTDController.pm
+++ b/src/Milton/Controller/RTDController.pm
@@ -5,6 +5,11 @@ use Milton::Math::PiecewiseLinear;
 use base qw(Milton::Controller);
 use Readonly;
 use Carp qw(croak);
+use Data::Dumper;
+use Milton::DataLogger qw(get_namespace_debug_level);
+
+use constant DEBUG_LEVEL => get_namespace_debug_level();
+use constant DEBUG_STATUS => 150;
 
 Readonly my $ALPHA_CU => 0.00393;
 
@@ -172,6 +177,12 @@ sub getTemperature {
   }
   $self->{'last-temperature'} = $temperature;
   $status->{temperature} = $temperature;
+  $self->debug("status: ". Dumper($status)) if DEBUG_LEVEL >= DEBUG_STATUS;
+
+  # If we have a predictor, use it now
+  if (defined $self->{predictor}) {
+    $self->{'predict-temperature'} = $self->{predictor}->predictTemperature($status);
+  }
 
   return $temperature;
 }

--- a/src/Milton/Controller/RTDController.pm
+++ b/src/Milton/Controller/RTDController.pm
@@ -32,9 +32,13 @@ sub new {
 
   my $self = $class->SUPER::new($config, $interface);
 
-  # Convert the temperature/resistance values into a piecewise linear estimator
+  # Convert the resistance/temperature values into a piecewise linear estimator
   $self->{rt_estimator} = Milton::Math::PiecewiseLinear->new
           ->addHashPoints('resistance', 'temperature', @{$config->{calibration}->{temperatures}});
+
+  # Convert the temperature/resistance values into a piecewise linear estimator for reverse estimation
+  $self->{tr_estimator} = Milton::Math::PiecewiseLinear->new
+          ->addHashPoints('temperature', 'resistance', @{$config->{calibration}->{temperatures}});
 
   if ($config->{'device'}) {
     $self->_initializeDevice($config->{'device'});
@@ -144,7 +148,7 @@ sub getTemperature {
   # If the estimator is empty, give it some sane defaults assuming a copper heating element
   if ($est->length() == 0 && !$self->{reset}) {
     my $ambient = $self->getAmbient($status);
-    $est->addNamedPoint($resistance, $ambient, 'ambient');
+    $self->setTemperaturePoint($ambient, $resistance, 'ambient');
     $self->warning("Auto-adding calibration point at T=$ambient, R=$resistance (name: ambient)");
   }
   
@@ -162,8 +166,8 @@ sub getTemperature {
       $t1 = 20;
       $r1 = ($r0 / (1 + $ALPHA_CU * ($t0 - $t1)));
     }
+    $self->setTemperaturePoint($t1, $r1, 'interpolated');
     $self->warning("Auto-adding calibration point at T=$t1, R=$r1 (name: interpolated)");
-    $est->addNamedPoint($r1, $t1, 'interpolated');
   }
 
   my $temperature = $est->estimate($resistance);
@@ -206,8 +210,14 @@ The measured resistance of the hotplate at this calibration point.
 =cut
 
 sub setTemperaturePoint {
-  my ($self, $temperature, $resistance) = @_;
-  $self->{rt_estimator}->addPoint($resistance, $temperature);
+  my ($self, $temperature, $resistance, $name) = @_;
+  if (defined $name) {
+    $self->{rt_estimator}->addNamedPoint($resistance, $temperature, $name);
+    $self->{tr_estimator}->addNamedPoint($temperature, $resistance, $name);
+  } else {
+    $self->{rt_estimator}->addPoint($resistance, $temperature);
+    $self->{tr_estimator}->addPoint($temperature, $resistance);
+  }
 }
 
 =head2 getTemperaturePoints
@@ -219,6 +229,29 @@ Get the list of temperature calibration points.
 sub getTemperaturePoints {
   my ($self) = @_;
   return $self->{rt_estimator}->getPoints();
+}
+
+=head2 estimateResistance($temperature)
+
+Estimate the resistance of the hotplate at a given temperature.
+
+=over
+
+=item $temperature
+
+The temperature in celsius for which an exstimated resistance is desired.
+
+=item Return Value
+
+The estimated resistance of the heating element at the specified temperature, specified in ohms.
+
+=back
+
+=cut
+
+sub estimateResistance {
+  my ($self, $temperature) = @_;
+  return $self->{tr_estimator}->estimate($temperature);
 }
 
 =head2 temperatureEstimatorLength()

--- a/src/Milton/Device/Brymen/BM2257.pm
+++ b/src/Milton/Device/Brymen/BM2257.pm
@@ -29,7 +29,10 @@ sub identify {
   while ($i > 0) {
     if ($self->readBuffer($helper) > 0) {
       $packet = $self->receiveData($helper);
-      return if $packet;
+      if ($packet) {
+        $self->info("BM2257 Multimeter connected on $helper->{'connected-device'}");
+        return;
+      }
     }
 
     $i--;

--- a/src/Milton/EventLoop.pm
+++ b/src/Milton/EventLoop.pm
@@ -574,15 +574,22 @@ sub _timerWatcher {
   my $cmd = $self->{command};
   my $status;
   my $rc;
+  my $now = $self->_now;
 
   eval {
     $status = $self->poll('timerEvent'
                         , now => $self->_now
                         , ambient => $self->{ambient}
                         );
+    if (defined $self->{past}) {
+      $status->{past} = $self->{past};
+      $status->{elapsed} = $now - $self->{past};
+    }
 
     $rc = $cmd->timerEvent($status);
   };
+  $self->{past} = $now;
+
   if ($@) {
     $self->{logger}->error("Error in timerEvent: $@");
     $evl->send;

--- a/webui/MiltonUI/CommandExecutor.pm
+++ b/webui/MiltonUI/CommandExecutor.pm
@@ -212,6 +212,20 @@ sub executeReplay {
   return $self->executeCommand('replay', @cmd);
 }
 
+sub executeVoltage {
+  my ($self, $params) = @_;
+
+  # Build command line
+  my @cmd = $self->initializeCommand($params);
+  
+  # Add replay command and file
+  push @cmd, 'voltage';
+  push @cmd, '--duration', $params->{duration} if defined $params->{duration};
+  push @cmd, $params->{voltage};
+
+  return $self->executeCommand('voltage', @cmd);
+}
+
 sub executePower {
   my ($self, $params) = @_;
 

--- a/webui/milton.pl
+++ b/webui/milton.pl
@@ -93,6 +93,22 @@ group {
                                                        , $PARAM_DEVICE
                                                        ]
                                        }
+                                     , { name => 'voltage'
+                                       , description => 'Constant voltage'
+                                       , parameters => [ { name => 'voltage'
+                                                         , type => 'number'
+                                                         , required => 1
+                                                         , description => 'Voltage to apply in volts'
+                                                         }
+                                                       , { name => 'duration'
+                                                         , type => 'number'
+                                                         , required => 0
+                                                         , description => 'Duration of voltage application in seconds (optional)'
+                                                         }
+                                                       , $PARAM_AMBIENT
+                                                       , $PARAM_DEVICE
+                                                       ]
+                                       }
                                      , { name => 'onePointCal'
                                        , description => 'One-point calibration'
                                        , parameters => [ $PARAM_AMBIENT
@@ -121,6 +137,7 @@ group {
                                                          , url => '/api/linear/profiles'
                                                          }
                                                        , $PARAM_AMBIENT
+                                                       , $PARAM_DEVICE
                                                        , { name => 'tune'
                                                          , type => 'boolean'
                                                          , required => 0

--- a/webui/milton.pl
+++ b/webui/milton.pl
@@ -74,6 +74,11 @@ group {
                       , description => 'Reflow Profile (optional)'
                       , url => '/api/reflow/profiles'
                       };
+  my $PARAM_RESET = { name => 'reset'
+                       , type => 'boolean'
+                       , required => 0
+                       , description => 'Ignore existing temperature calibration'
+                       };
   # List available commands
   get '/api/commands' => sub {
     my $c = shift;
@@ -91,6 +96,7 @@ group {
                                                          }
                                                        , $PARAM_AMBIENT
                                                        , $PARAM_DEVICE
+                                                       , $PARAM_RESET
                                                        ]
                                        }
                                      , { name => 'voltage'
@@ -107,6 +113,7 @@ group {
                                                          }
                                                        , $PARAM_AMBIENT
                                                        , $PARAM_DEVICE
+                                                       , $PARAM_RESET
                                                        ]
                                        }
                                      , { name => 'onePointCal'
@@ -215,6 +222,7 @@ group {
                                                          , order => 8
                                                          }
                                                        , $PARAM_DEVICE
+                                                       , $PARAM_RESET
                                                        ]
                                        }
                                      , { name => 'rth'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the hotplate control path to sometimes drive the PSU via `setVoltage` (derived from estimated resistance) and alters stage-transition logic to use predicted temperatures, which could impact thermal behavior and safety limits if estimation is off.
> 
> **Overview**
> `linear` profile execution now derives a per-stage voltage target from estimated hotplate resistance (via new RTD reverse estimation) and applies *trimmed* stage power/voltage during `timerEvent`, using predicted temperature for stage start/threshold decisions.
> 
> Adds a new `voltage` command for constant-voltage operation and wires it into the Web UI/API. Also improves timing/prediction robustness by logging multimeter connection, tracking `elapsed` time in the event loop, and letting `BandedLPF` use actual elapsed period when timer drift is detected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 477660987de200d858a46468c55da4b78fe220ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->